### PR TITLE
Update portfolio after trades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+**/__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
-# stock_full
-trading game
+# Stock Trading App
+
+This repository contains a simple trading application that uses [Supabase](https://supabase.com/) to fetch daily prices and store portfolio P&L information.
+
+## Requirements
+- Python 3.12
+- `supabase` Python client (`pip install supabase`)
+- `fastapi` and `uvicorn` for the Vercel API
+
+Environment variables `SUPABASE_URL` and `SUPABASE_KEY` must be set with your Supabase credentials.
+
+## Usage
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set the `SUPABASE_URL` and `SUPABASE_KEY` environment variables.
+3. Run the script locally:
+   ```bash
+   python trading_app.py
+   ```
+   Edit the example usage at the bottom of `trading_app.py` to place orders.
+
+The script writes to a `p&l` table with your cash balance, unrealized profit and loss, and total portfolio value.  A row is updated whenever you buy or sell shares so the table always reflects the latest state for the current day.
+
+### Daily Prices Table
+
+Create a `daily_prices` table in Supabase containing the columns:
+
+```
+symbol text
+date date
+close_price numeric
+```
+
+The app uses the most recent `close_price` for each symbol when processing trades.
+
+### Creating the P&L table
+
+Use the Supabase CLI to create a table for daily performance metrics:
+
+```bash
+supabase db query <<'SQL'
+CREATE TABLE "p&l" (
+  username text,
+  date date PRIMARY KEY,
+  unrealized_pnl numeric,
+  cash numeric,
+  total numeric
+);
+SQL
+```
+
+### Frontend
+
+`index.html` provides a simple interface to buy or sell shares. The page uses the FastAPI endpoints under `/api` and shows your cash balance, open positions, unrealized P&L and total equity after each trade.
+
+## Deploying to Vercel
+
+Create a Vercel project and push this repository. Vercel detects the `api/index.py` function and deploys it as a serverless API. Ensure your Supabase credentials are set as environment variables in the Vercel dashboard.

--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI, HTTPException
+from trading_app import create_app
+
+app = FastAPI()
+trader = create_app()
+
+@app.post("/buy")
+def buy(symbol: str, quantity: int):
+    try:
+        summary = trader.buy(symbol, quantity)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return summary
+
+@app.post("/sell")
+def sell(symbol: str, quantity: int):
+    try:
+        summary = trader.sell(symbol, quantity)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return summary
+
+@app.post("/update")
+def update():
+    summary = trader.update_daily_pnl()
+    return summary
+
+
+@app.get("/portfolio")
+def portfolio():
+    """Return current cash, holdings and unrealized P&L."""
+    return trader.update_daily_pnl()

--- a/index.html
+++ b/index.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Trading App</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 600px; margin: auto; padding: 2rem; }
+    form { margin-bottom: 1rem; }
+    label { display: block; margin-bottom: 0.25rem; }
+    input[type="text"], input[type="number"] { width: 100%; padding: 0.5rem; margin-bottom: 0.5rem; }
+    button { padding: 0.5rem 1rem; }
+    #portfolio { margin-top: 2rem; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }
+  </style>
+</head>
+<body>
+  <h1>Trading App</h1>
+
+  <form id="buy-form">
+    <h2>Buy</h2>
+    <label>Symbol <input type="text" id="buy-symbol" required></label>
+    <label>Quantity <input type="number" id="buy-qty" required></label>
+    <button type="submit">Buy</button>
+  </form>
+
+  <form id="sell-form">
+    <h2>Sell</h2>
+    <label>Symbol <input type="text" id="sell-symbol" required></label>
+    <label>Quantity <input type="number" id="sell-qty" required></label>
+    <button type="submit">Sell</button>
+  </form>
+
+  <div id="portfolio">
+    <h2>Portfolio</h2>
+    <p>Cash: $<span id="cash">0</span></p>
+    <p>Unrealized P&amp;L: $<span id="pnl">0</span></p>
+    <p>Total: $<span id="total">0</span></p>
+    <table id="holdings-table">
+      <thead>
+        <tr><th>Symbol</th><th>Quantity</th><th>Avg Price</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
+  <script>
+    async function fetchPortfolio() {
+      const res = await fetch('/api/portfolio');
+      if (!res.ok) return;
+      const data = await res.json();
+      updatePortfolio(data);
+    }
+
+    function updatePortfolio(data) {
+      document.getElementById('cash').textContent = data.cash.toFixed(2);
+      document.getElementById('pnl').textContent = data.unrealized_pnl.toFixed(2);
+      document.getElementById('total').textContent = data.total.toFixed(2);
+      const tbody = document.getElementById('holdings-table').querySelector('tbody');
+      tbody.innerHTML = '';
+      for (const [symbol, info] of Object.entries(data.holdings)) {
+        const row = document.createElement('tr');
+        row.innerHTML = `<td>${symbol}</td><td>${info.quantity}</td><td>${info.avg_price.toFixed(2)}</td>`;
+        tbody.appendChild(row);
+      }
+    }
+
+    document.getElementById('buy-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const symbol = document.getElementById('buy-symbol').value;
+      const qty = parseInt(document.getElementById('buy-qty').value, 10);
+      const res = await fetch('/api/buy?symbol=' + encodeURIComponent(symbol) + '&quantity=' + qty, { method: 'POST' });
+      const data = await res.json();
+      updatePortfolio(data);
+    });
+
+    document.getElementById('sell-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const symbol = document.getElementById('sell-symbol').value;
+      const qty = parseInt(document.getElementById('sell-qty').value, 10);
+      const res = await fetch('/api/sell?symbol=' + encodeURIComponent(symbol) + '&quantity=' + qty, { method: 'POST' });
+      const data = await res.json();
+      updatePortfolio(data);
+    });
+
+    fetchPortfolio();
+  </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+supabase>=2.17.0
+fastapi>=0.116.0
+uvicorn>=0.29.0

--- a/trading_app.py
+++ b/trading_app.py
@@ -1,0 +1,102 @@
+import os
+from datetime import date
+from typing import Dict, Any
+
+from supabase import create_client, Client
+
+
+class TradingApp:
+    def __init__(self, url: str, key: str, starting_cash: float = 1_000_000):
+        self.supabase: Client = create_client(url, key)
+        self.cash: float = starting_cash
+        self.holdings: Dict[str, Dict[str, float]] = {}
+
+    def _get_latest_price(self, symbol: str) -> float:
+        response = (
+            self.supabase.table("daily_prices")
+            .select("close_price")
+            .eq("symbol", symbol)
+            .order("date", desc=True)
+            .limit(1)
+            .execute()
+        )
+        if not response.data:
+            raise ValueError(f"No price data for symbol {symbol}")
+        return float(response.data[0]["close_price"])
+
+    def buy(self, symbol: str, quantity: int) -> Dict[str, Any]:
+        if symbol not in self.holdings and len(self.holdings) >= 10:
+            raise ValueError("Maximum number of holdings reached")
+        price = self._get_latest_price(symbol)
+        cost = price * quantity
+        if cost > self.cash:
+            raise ValueError("Insufficient cash")
+        self.cash -= cost
+        position = self.holdings.get(symbol, {"quantity": 0, "avg_price": 0.0})
+        new_quantity = position["quantity"] + quantity
+        new_avg_price = (
+            position["quantity"] * position["avg_price"] + cost
+        ) / new_quantity
+        self.holdings[symbol] = {"quantity": new_quantity, "avg_price": new_avg_price}
+        return self.update_daily_pnl()
+
+    def sell(self, symbol: str, quantity: int) -> Dict[str, Any]:
+        if symbol not in self.holdings or self.holdings[symbol]["quantity"] < quantity:
+            raise ValueError("Not enough shares to sell")
+        price = self._get_latest_price(symbol)
+        proceeds = price * quantity
+        self.cash += proceeds
+        position = self.holdings[symbol]
+        position["quantity"] -= quantity
+        if position["quantity"] == 0:
+            del self.holdings[symbol]
+        else:
+            self.holdings[symbol] = position
+        return self.update_daily_pnl()
+
+    def _compute_unrealized_pnl(self) -> float:
+        pnl = 0.0
+        for symbol, position in self.holdings.items():
+            price = self._get_latest_price(symbol)
+            pnl += (price - position["avg_price"]) * position["quantity"]
+        return pnl
+
+    def _portfolio_summary(self) -> Dict[str, Any]:
+        """Return cash, holdings, and unrealized P&L totals."""
+        pnl = self._compute_unrealized_pnl()
+        total = self.cash + pnl
+        return {
+            "cash": self.cash,
+            "holdings": self.holdings,
+            "unrealized_pnl": pnl,
+            "total": total,
+        }
+
+    def update_daily_pnl(self) -> Dict[str, Any]:
+        summary = self._portfolio_summary()
+        self.supabase.table("p&l").upsert(
+            {
+                "date": date.today().isoformat(),
+                "cash": summary["cash"],
+                "unrealized_pnl": summary["unrealized_pnl"],
+                "total": summary["total"],
+            },
+            on_conflict="date",
+        ).execute()
+        return summary
+
+
+def create_app() -> TradingApp:
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_KEY")
+    if not url or not key:
+        raise EnvironmentError("SUPABASE_URL and SUPABASE_KEY must be set")
+    return TradingApp(url, key)
+
+
+if __name__ == "__main__":
+    app = create_app()
+    # Example usage
+    # app.buy("AAPL", 10)
+    # app.sell("AAPL", 5)
+    app.update_daily_pnl()


### PR DESCRIPTION
## Summary
- automatically update P&L in `TradingApp.buy` and `sell`
- expose updated portfolio values via API endpoints
- show unrealized P&L and total equity in the web UI
- document the automatic P&L update in README

## Testing
- `python -m py_compile trading_app.py api/index.py`

------
https://chatgpt.com/codex/tasks/task_e_687ee994643c832fa28d2bd8682ccc05