### PR TITLE
Persist holdings in Supabase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 **/__pycache__/
 *.pyc
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,18 +1,25 @@
 # Stock Trading App
 
 This repository contains a simple trading application that uses [Supabase](https://supabase.com/) to fetch daily prices and store portfolio P&L information.
+It includes both a Python script and a small JavaScript API that can run on Vercel.
 
 ## Requirements
-- Python 3.12
+- Python 3.12 (if using the Python script)
+- Node.js 18+ (for the Vercel API)
 - `supabase` Python client (`pip install supabase`)
-- `fastapi` and `uvicorn` for the Vercel API
+- `fastapi` and `uvicorn` for the Python API
+- `@supabase/supabase-js` for the JavaScript API
 
 Environment variables `SUPABASE_URL` and `SUPABASE_KEY` must be set with your Supabase credentials.
 
 ## Usage
 1. Install dependencies:
    ```bash
+   # Python dependencies
    pip install -r requirements.txt
+   
+   # JavaScript dependencies
+   npm install
    ```
 2. Set the `SUPABASE_URL` and `SUPABASE_KEY` environment variables.
 3. Run the script locally:
@@ -25,4 +32,6 @@ Environment variables `SUPABASE_URL` and `SUPABASE_KEY` must be set with your Su
 
 ## Deploying to Vercel
 
-Create a Vercel project and push this repository. Vercel detects the `api/index.py` function and deploys it as a serverless API. Ensure your Supabase credentials are set as environment variables in the Vercel dashboard.
+The JavaScript API under `pages/api` is designed for Vercel. Push this repository and Vercel will deploy those routes automatically. Ensure the environment variables `SUPABASE_URL` and `SUPABASE_KEY` are configured in the Vercel dashboard.
+
+The API expects a table named `holdings` in Supabase where it stores the latest quantity and average price for each symbol after every trade.

--- a/lib/createApp.js
+++ b/lib/createApp.js
@@ -1,8 +1,11 @@
 import { TradingApp } from './tradingApp'
 
-export function createApp() {
+export async function createApp() {
   const url = process.env.SUPABASE_URL
   const key = process.env.SUPABASE_KEY
-  if (!url || !key) throw new Error("Missing Supabase credentials")
-  return new TradingApp(url, key)
+  if (!url || !key) throw new Error('Missing Supabase credentials')
+
+  const app = new TradingApp(url, key)
+  await app.loadHoldings()
+  return app
 }

--- a/lib/tradingApp.js
+++ b/lib/tradingApp.js
@@ -7,6 +7,34 @@ export class TradingApp {
     this.holdings = {} // symbol -> { quantity, avg_price }
   }
 
+  async loadHoldings() {
+    const { data, error } = await this.supabase
+      .from('holdings')
+      .select('symbol, quantity, avg_price')
+
+    if (error) throw new Error(`Failed to load holdings: ${error.message}`)
+
+    this.holdings = {}
+    for (const row of data) {
+      this.holdings[row.symbol] = {
+        quantity: row.quantity,
+        avg_price: row.avg_price,
+      }
+    }
+  }
+
+  async saveHolding(symbol) {
+    const pos = this.holdings[symbol]
+    if (!pos) {
+      await this.supabase.from('holdings').delete().eq('symbol', symbol)
+      return
+    }
+    await this.supabase.from('holdings').upsert(
+      { symbol, quantity: pos.quantity, avg_price: pos.avg_price },
+      { onConflict: ['symbol'] }
+    )
+  }
+
   async getLatestPrice(symbol) {
     const { data, error } = await this.supabase
       .from('daily_prices')
@@ -34,6 +62,7 @@ export class TradingApp {
     const newAvg = (prev.quantity * prev.avg_price + cost) / newQty
 
     this.holdings[symbol] = { quantity: newQty, avg_price: newAvg }
+    await this.saveHolding(symbol)
     return this.updateDailyPnl()
   }
 
@@ -52,6 +81,7 @@ export class TradingApp {
       this.holdings[symbol] = { quantity: remaining, avg_price: pos.avg_price }
     }
 
+    await this.saveHolding(symbol)
     return this.updateDailyPnl()
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,176 @@
+{
+  "name": "stock-trading-app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "stock-trading-app",
+      "dependencies": {
+        "@supabase/supabase-js": "^2.39.5"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.11.15",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.15.tgz",
+      "integrity": "sha512-HQKRnwAqdVqJW/P9TjKVK+/ETpW4yQ8tyDPPtRMKOH4Uh3vQD74vmj353CYs8+YwVBKubeUOOEpI9CT8mT4obw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "isows": "^1.0.7",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.52.0.tgz",
+      "integrity": "sha512-jbs3CV1f2+ge7sgBeEduboT9v/uGjF22v0yWi/5/XFn5tbM8MfWRccsMtsDwAwu24XK8H6wt2LJDiNnZLtx/bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.5",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.11.15",
+        "@supabase/storage-js": "2.7.1"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "stock-trading-app",
+  "type": "module",
+  "dependencies": {
+    "@supabase/supabase-js": "^2.39.5"
+  }
+}

--- a/pages/api/buy.js
+++ b/pages/api/buy.js
@@ -1,9 +1,9 @@
-import { createApp } from '@/lib/createApp'
+import { createApp } from '../../lib/createApp.js'
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') return res.status(405).end()
   const { symbol, quantity } = req.query
-  const app = createApp()
+  const app = await createApp()
   try {
     const summary = await app.buy(symbol, parseInt(quantity))
     res.status(200).json(summary)

--- a/pages/api/portfolio.js
+++ b/pages/api/portfolio.js
@@ -1,8 +1,8 @@
-import { createApp } from '@/lib/createApp'
+import { createApp } from '../../lib/createApp.js'
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') return res.status(405).end()
-  const app = createApp()
+  const app = await createApp()
   try {
     const summary = await app.updateDailyPnl()
     res.status(200).json(summary)

--- a/pages/api/sell.js
+++ b/pages/api/sell.js
@@ -1,9 +1,9 @@
-import { createApp } from '@/lib/createApp'
+import { createApp } from '../../lib/createApp.js'
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') return res.status(405).end()
   const { symbol, quantity } = req.query
-  const app = createApp()
+  const app = await createApp()
   try {
     const summary = await app.sell(symbol, parseInt(quantity))
     res.status(200).json(summary)


### PR DESCRIPTION
## Summary
- add persistent holdings storage to the JS TradingApp
- load holdings on initialization
- update API routes to await `createApp`
- provide package.json for the JS API and ignore node_modules
- document JS deployment and Supabase table

## Testing
- `node --check lib/tradingApp.js`
- `node --check pages/api/buy.js`
- `node --check pages/api/sell.js`
- `node --check pages/api/portfolio.js`
- `python -m py_compile trading_app.py`
- `python -m py_compile api/index.py`


------
https://chatgpt.com/codex/tasks/task_e_68802fd241f4832fa38ec258fadd6201